### PR TITLE
cicd: modified javadoc publish dir

### DIFF
--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -25,5 +25,5 @@ jobs:
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./doc/api
+        publish_dir: ./target/site/apidocs
 


### PR DESCRIPTION
This PR corrects a mistake.