### PR TITLE
fix: suppressed warnings of heap pollutions via varargs parameter

### DIFF
--- a/src/main/java/sabi/Proc.java
+++ b/src/main/java/sabi/Proc.java
@@ -56,7 +56,8 @@ public class Proc<D> {
    * @param logics  Logic functional interfaces.
    * @throws Err  If an exception occurs in a logic.
    */
-  public void runTxn(final Logic<D> ...logics) throws Err {
+  @SafeVarargs
+  public final void runTxn(final Logic<D> ...logics) throws Err {
     var base = DaxBase.class.cast(dax);
 
     try {
@@ -83,7 +84,8 @@ public class Proc<D> {
    * @param logics  {@link Logic} objects.
    * @return A {@link Runner} object which processes a transaction.
    */
-  public Runner txn(final Logic<D> ...logics) {
+  @SafeVarargs
+  public final Runner txn(final Logic<D> ...logics) {
     return new Runner() {
       @Override
       public void run() throws Err {


### PR DESCRIPTION
`Proc#runTxn` and `Proc#txn` uses variadic arguments with a type parameter, and compiler outputs warnings of possibility of heap pollutions at these methods.

Since these methods does not modify their argument arrays and there are no possibility of heap pollutions, `@SafeVarargs` annotation and `final` morifier are attached to each of these methods to suppress the warnings.  