### PR TITLE
chore: enabled to publish to a local maven repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,4 +97,12 @@
     </plugins>
   </build>
 
+  <distributionManagement>
+    <repository>
+      <id>local-m2-repository</id>
+      <name>Local Maven Repository</name>
+      <url>file://${user.dir}/../local-m2-repository</url>
+    </repository>
+  </distributionManagement>
+
 </project>


### PR DESCRIPTION
This PR adds `<distributionManagement>` to `pom.xml` for publishing to `../local-m2-repository`.