### PR TITLE
update!: changed APIs of Err, etc. according with sttk-go/sabi

### DIFF
--- a/src/main/java/sabi/Err.java
+++ b/src/main/java/sabi/Err.java
@@ -1,6 +1,6 @@
 /*
  * Err class.
- * Copyright (C) 2022 Takayuki Sato. All Rights Reserved.
+ * Copyright (C) 2022-2023 Takayuki Sato. All Rights Reserved.
  */
 package sabi;
 
@@ -201,9 +201,11 @@ public final class Err extends Exception {
   /**
    * Returns the name of the source file of this error occurrence.
    *
+   * This method returns null if this information is unavailable.
+   *
    * @return  The name of the source file of this error occurrence.
    */
-  public String getFileName() {
+  protected String getFileName() {
     return trace.getFileName();
   }
 
@@ -211,9 +213,11 @@ public final class Err extends Exception {
   /**
    * Returns the name of the source file of this error occurrence.
    *
+   * This method returns a negative number if this information is unavailable.
+   *
    * @return  The name of the source file of this error occurrence.
    */
-  public int getLineNumber() {
+  protected int getLineNumber() {
     return trace.getLineNumber();
   }
 
@@ -228,8 +232,8 @@ public final class Err extends Exception {
    *
    * @param handler  An {@link ErrHandler} object.
    */
-  public static void addSyncHandler(final ErrHandler handler) {
-    notifier.addSyncHandler(handler);
+  public static void addSyncErrHandler(final ErrHandler handler) {
+    notifier.addSyncErrHandler(handler);
   }
 
 
@@ -242,18 +246,18 @@ public final class Err extends Exception {
    *
    * @param handler  An {@link ErrHandler} object.
    */
-  public static void addAsyncHandler(final ErrHandler handler) {
-    notifier.addAsyncHandler(handler);
+  public static void addAsyncErrHandler(final ErrHandler handler) {
+    notifier.addAsyncErrHandler(handler);
   }
 
 
   /**
-   * Seals configurations for {@link Err}.
+   * Fixes configuration for {@link Err}s.
    *
    * After calling this method, any more {@link ErrHandler}s cannot be
    * registered and notification of {@link Err} creations becomes effective.
    */
-  public static void sealErrCfgs() {
-    notifier.seal();
+  public static void fixErrCfgs() {
+    notifier.fix();
   }
 }

--- a/src/main/java/sabi/ErrHandler.java
+++ b/src/main/java/sabi/ErrHandler.java
@@ -16,7 +16,8 @@ public interface ErrHandler {
    * Handles an {@link Err} object which will be created rigth after.
    *
    * @param err  An {@link Err} object.
-   * @param odt  {@link OffsetDateTime} object which is the current time.
+   * @param errOcc  An {@link ErrOccasion} object which holds when and where
+   *   an Err occured.
    */
-  void handle(Err err, OffsetDateTime odt);
+  void handle(Err err, ErrOccasion errOcc);
 }

--- a/src/main/java/sabi/ErrOccasion.java
+++ b/src/main/java/sabi/ErrOccasion.java
@@ -1,0 +1,67 @@
+/*
+ * ErrOccasion class.
+ * Copyright (C) 2023 Takayuki Sato. All Rights Reserved.
+ */
+package sabi;
+
+import java.time.OffsetDateTime;
+
+/**
+ * ErrOccasion is a class which contains time and position in a source file
+ * when and where an Err occured.
+ */
+public final class ErrOccasion {
+
+  /** Time when an Err occured. */
+  private final OffsetDateTime time;
+
+  /** The source file name where an Err occured. */
+  private final String file;
+
+  /** The line number where an Err occured. */
+  private final int line;
+
+  /**
+   * The constructor which takes an Err object.
+   *
+   * @param  err An Err object.
+   */
+  public ErrOccasion(final Err err) {
+    this.time = OffsetDateTime.now();
+    this.file = err.getFileName();
+    this.line = err.getLineNumber();
+  }
+
+  /**
+   * Gets time when an Err occured.
+   *
+   * @return  A {@link OffsetDateTime} object.
+   */
+  public OffsetDateTime getTime() {
+    return time;
+  }
+
+  /**
+   * Gets a source file name where an Err occured.
+   *
+   * This source file name is null if this is unavailable in the stack trace
+   * element.
+   *
+   * @return  A source file name.
+   */
+  public String getFile() {
+    return file;
+  }
+
+  /**
+   * Gets a line number where an Err occured.
+   *
+   * This line number is a nevative number if this is unavailable in the stack
+   * trace element.
+   *
+   * @return  A line number.
+   */
+  public int getLine() {
+    return line;
+  }
+}

--- a/src/test/java/sabi/ErrHandlerTest.java
+++ b/src/test/java/sabi/ErrHandlerTest.java
@@ -16,19 +16,19 @@ public class ErrHandlerTest {
 
   @Test
   public void should_notify_that_errs_are_created() {
-    Err.addSyncHandler((err, odt) -> {
+    Err.addSyncErrHandler((err, odt) -> {
       syncLogger.add("1. " + err.getReason().toString());
     });
-    Err.addSyncHandler((err, odt) -> {
+    Err.addSyncErrHandler((err, odt) -> {
       syncLogger.add("2. " + err.getReason().toString());
     });
-    Err.addAsyncHandler((err, odt) -> {
+    Err.addAsyncErrHandler((err, odt) -> {
       asyncLogger.add("3. " + err.getReason().toString());
     });
-    Err.addAsyncHandler((err, odt) -> {
+    Err.addAsyncErrHandler((err, odt) -> {
       asyncLogger.add("4. " + err.getReason().toString());
     });
-    Err.sealErrCfgs();
+    Err.fixErrCfgs();
 
     try {
       throw new Err(new FailToDoSomething("abc"));

--- a/src/test/java/sabi/notify/ErrNotifierTest.java
+++ b/src/test/java/sabi/notify/ErrNotifierTest.java
@@ -13,49 +13,49 @@ import java.util.ArrayList;
 public class ErrNotifierTest {
 
   @Test
-  void should_add_handlers_and_seal() {
+  void should_add_err_handlers_and_fix() {
     final var notifier = new ErrNotifier();
-    assertThat(notifier.isSealed()).isFalse();
-    assertThat(notifier.syncHandlers).isEmpty();
-    assertThat(notifier.asyncHandlers).isEmpty();
+    assertThat(notifier.isFixed()).isFalse();
+    assertThat(notifier.syncErrHandlers).isEmpty();
+    assertThat(notifier.asyncErrHandlers).isEmpty();
 
     final ErrHandler h1 = (err, odt) -> {};
-    notifier.addSyncHandler(h1);
-    assertThat(notifier.isSealed()).isFalse();
-    assertThat(notifier.syncHandlers).containsExactly(h1);
-    assertThat(notifier.asyncHandlers).isEmpty();
+    notifier.addSyncErrHandler(h1);
+    assertThat(notifier.isFixed()).isFalse();
+    assertThat(notifier.syncErrHandlers).containsExactly(h1);
+    assertThat(notifier.asyncErrHandlers).isEmpty();
 
     final ErrHandler h2 = (err, odt) -> {};
-    notifier.addSyncHandler(h2);
-    assertThat(notifier.isSealed()).isFalse();
-    assertThat(notifier.syncHandlers).containsExactly(h1, h2);
-    assertThat(notifier.asyncHandlers).isEmpty();
+    notifier.addSyncErrHandler(h2);
+    assertThat(notifier.isFixed()).isFalse();
+    assertThat(notifier.syncErrHandlers).containsExactly(h1, h2);
+    assertThat(notifier.asyncErrHandlers).isEmpty();
 
     final ErrHandler h3 = (err, odt) -> {};
-    notifier.addAsyncHandler(h3);
-    assertThat(notifier.isSealed()).isFalse();
-    assertThat(notifier.syncHandlers).containsExactly(h1, h2);
-    assertThat(notifier.asyncHandlers).containsExactly(h3);
+    notifier.addAsyncErrHandler(h3);
+    assertThat(notifier.isFixed()).isFalse();
+    assertThat(notifier.syncErrHandlers).containsExactly(h1, h2);
+    assertThat(notifier.asyncErrHandlers).containsExactly(h3);
 
     final ErrHandler h4 = (err, odt) -> {};
-    notifier.addAsyncHandler(h4);
-    assertThat(notifier.isSealed()).isFalse();
-    assertThat(notifier.syncHandlers).containsExactly(h1, h2);
-    assertThat(notifier.asyncHandlers).containsExactly(h3, h4);
+    notifier.addAsyncErrHandler(h4);
+    assertThat(notifier.isFixed()).isFalse();
+    assertThat(notifier.syncErrHandlers).containsExactly(h1, h2);
+    assertThat(notifier.asyncErrHandlers).containsExactly(h3, h4);
 
-    notifier.seal();
+    notifier.fix();
 
     final ErrHandler h5 = (err, odt) -> {};
-    notifier.addSyncHandler(h5);
-    assertThat(notifier.isSealed()).isTrue();
-    assertThat(notifier.syncHandlers).containsExactly(h1, h2);
-    assertThat(notifier.asyncHandlers).containsExactly(h3, h4);
+    notifier.addSyncErrHandler(h5);
+    assertThat(notifier.isFixed()).isTrue();
+    assertThat(notifier.syncErrHandlers).containsExactly(h1, h2);
+    assertThat(notifier.asyncErrHandlers).containsExactly(h3, h4);
 
     final ErrHandler h6 = (err, odt) -> {};
-    notifier.addAsyncHandler(h6);
-    assertThat(notifier.isSealed()).isTrue();
-    assertThat(notifier.syncHandlers).containsExactly(h1, h2);
-    assertThat(notifier.asyncHandlers).containsExactly(h3, h4);
+    notifier.addAsyncErrHandler(h6);
+    assertThat(notifier.isFixed()).isTrue();
+    assertThat(notifier.syncErrHandlers).containsExactly(h1, h2);
+    assertThat(notifier.asyncErrHandlers).containsExactly(h3, h4);
   }
 
   // error reason
@@ -83,7 +83,7 @@ public class ErrNotifierTest {
       final var logs = new ArrayList<String>();
 
       final var notifier = new ErrNotifier();
-      notifier.addSyncHandler((err, odt) -> {
+      notifier.addSyncErrHandler((err, odt) -> {
         logs.add(err.getReason().toString());
       });
 
@@ -99,7 +99,7 @@ public class ErrNotifierTest {
 
       assertThat(logs).isEmpty();
 
-      notifier.seal();
+      notifier.fix();
 
       try {
         throw new Err(new FailToDoSomething("abc"));
@@ -119,7 +119,7 @@ public class ErrNotifierTest {
       final var logs = new ArrayList<String>();
 
       final var notifier = new ErrNotifier();
-      notifier.addAsyncHandler((err, odt) -> {
+      notifier.addAsyncErrHandler((err, odt) -> {
         logs.add(err.getReason().toString());
       });
 
@@ -136,7 +136,7 @@ public class ErrNotifierTest {
 
       assertThat(logs).isEmpty();
 
-      notifier.seal();
+      notifier.fix();
 
       try {
         throw new Err(new FailToDoSomething("abc"));
@@ -156,10 +156,10 @@ public class ErrNotifierTest {
     void should_execute_sync_and_async_handlers() {
       final var logs = new ArrayList<String>();
       final var notifier = new ErrNotifier();
-      notifier.addAsyncHandler((err, odt) -> {
+      notifier.addAsyncErrHandler((err, odt) -> {
         logs.add("Async: " + err.getReason());
       });
-      notifier.addSyncHandler((err, odt) -> {
+      notifier.addSyncErrHandler((err, odt) -> {
         logs.add("Sync: " + err.getReason());
       });
 
@@ -176,7 +176,7 @@ public class ErrNotifierTest {
 
       assertThat(logs).isEmpty();
 
-      notifier.seal();
+      notifier.fix();
 
       try {
         throw new Err(new FailToDoSomething("abc"));
@@ -199,16 +199,16 @@ public class ErrNotifierTest {
     void should_stop_executing_sync_handlers_if_one_of_handlers_failed() {
       final var logs = new ArrayList<String>();
       final var notifier = new ErrNotifier();
-      notifier.addAsyncHandler((err, odt) -> {
+      notifier.addAsyncErrHandler((err, odt) -> {
         logs.add("Async: " + err.getReason());
       });
-      notifier.addSyncHandler((err, odt) -> {
+      notifier.addSyncErrHandler((err, odt) -> {
         logs.add("Sync(1): " + err.getReason());
       });
-      notifier.addSyncHandler((err, odt) -> {
+      notifier.addSyncErrHandler((err, odt) -> {
         throw new RuntimeException();
       });
-      notifier.addSyncHandler((err, odt) -> {
+      notifier.addSyncErrHandler((err, odt) -> {
         logs.add("Sync(3): " + err.getReason());
       });
 
@@ -225,7 +225,7 @@ public class ErrNotifierTest {
 
       assertThat(logs).isEmpty();
 
-      notifier.seal();
+      notifier.fix();
 
       try {
         throw new Err(new FailToDoSomething("abc"));
@@ -250,16 +250,16 @@ public class ErrNotifierTest {
     void should_execute_all_async_handlers_even_if_one_of_handlers_failed() {
       final var logs = new ArrayList<String>();
       final var notifier = new ErrNotifier();
-      notifier.addAsyncHandler((err, odt) -> {
+      notifier.addAsyncErrHandler((err, odt) -> {
         logs.add("Async(1): " + err.getReason());
       });
-      notifier.addAsyncHandler((err, odt) -> {
+      notifier.addAsyncErrHandler((err, odt) -> {
         throw new RuntimeException();
       });
-      notifier.addAsyncHandler((err, odt) -> {
+      notifier.addAsyncErrHandler((err, odt) -> {
         logs.add("Async(3): " + err.getReason());
       });
-      notifier.addSyncHandler((err, odt) -> {
+      notifier.addSyncErrHandler((err, odt) -> {
         logs.add("Sync: " + err.getReason());
       });
 
@@ -276,7 +276,7 @@ public class ErrNotifierTest {
 
       assertThat(logs).isEmpty();
 
-      notifier.seal();
+      notifier.fix();
 
       try {
         throw new Err(new FailToDoSomething("abc"));


### PR DESCRIPTION
This PR changes APIs of `Err`, `ErrHandler`, and `ErrNotifier`, according with `sttk-go/sabi`.

- Access modifiers of `Err#getFileName` and `Err#getLineNumber` are changed from `public` to `protected`.
- `Err.addSyncHandler`, `Err. addAsyncHandler`, and `Err.sealErrCfgs` are renamed to `Err.addSyncErrHandler`, `Err. addAsyncErrHandler`, and `Err.fixErrCfgs`.
- Argument composition of `ErrHandler#handle` are changed from `(Err, OffsetDateTime)` to `(Err, ErrOccasion)`.