### PR TITLE
update!: changed GetDaxConn to cast a returned DaxConn

### DIFF
--- a/src/main/java/sabi/Dax.java
+++ b/src/main/java/sabi/Dax.java
@@ -15,8 +15,9 @@ public interface Dax {
    * name.
    *
    * @param name  The name of {@link DaxConn} or {@link DaxSrc}.
+   * @param cls  The class object of cast destination.
    * @return  A {@link DaxConn} object.
    * @throws Err  If failing to get {@link DaxConn}.
    */
-  DaxConn getDaxConn(final String name) throws Err;
+  <C extends DaxConn> C getDaxConn(String name, Class<C> cls) throws Err;
 }

--- a/src/main/java/sabi/DaxBase.java
+++ b/src/main/java/sabi/DaxBase.java
@@ -44,10 +44,11 @@ public abstract class DaxBase {
   /**
    * An error reason which indicates that it is failed to cast type of a
    * DaxConn.
-   * The field: name is a registered name of a DaxSrc which created the target
-   * DaxConn.
-   * And the fields: fromType and toType are the types of the source DaxConn
-   * and the destination DaxConn.
+   *
+   * @param name  A registered name of a {@link DaxSrc} which created the
+   *   target {@link DaxConn}.
+   * @param fromType  The type of the source {@link DaxConn}
+   * @param toType    The type of the destination {@link DaxConn}
    */
   public record FailToCastDaxConn(String name, String fromType, String toType) {};
 

--- a/src/test/java/sabi/DaxDummyForTest.java
+++ b/src/test/java/sabi/DaxDummyForTest.java
@@ -169,13 +169,6 @@ public class DaxDummyForTest {
     }
   }
 
-  static interface MapDax extends Dax {
-    default MapDaxConn getMapDaxConn(String name) throws Err {
-      var conn = getDaxConn(name);
-      return MapDaxConn.class.cast(conn);
-    }
-  }
-
   static interface HogeFugaDax extends Dax {
     String getHogeData() throws Err;
     void setFugaData(String data) throws Err;
@@ -202,41 +195,41 @@ public class DaxDummyForTest {
     }
   }
 
-  static interface HogeDax extends MapDax, HogeFugaDax {
+  static interface HogeDax extends Dax, HogeFugaDax {
     default String getHogeData() throws Err {
-      var conn = getMapDaxConn("hoge");
+      var conn = getDaxConn("hoge", MapDaxConn.class);
       var data = conn.dataMap.get("hogehoge");
       return data;
     }
 
     default void SetHogeData(String data) throws Err {
-      var conn = getMapDaxConn("hoge");
+      var conn = getDaxConn("hoge", MapDaxConn.class);
       conn.dataMap.put("hogehoge", data);
     }
   }
 
-  static interface FugaDax extends MapDax, HogeFugaDax, FugaPiyoDax {
+  static interface FugaDax extends Dax, HogeFugaDax, FugaPiyoDax {
     default String getFugaData() throws Err {
-      var conn = getMapDaxConn("fuga");
+      var conn = getDaxConn("fuga", MapDaxConn.class);
       var data = conn.dataMap.get("fugafuga");
       return data;
     }
 
     default void setFugaData(String data) throws Err {
-      var conn = getMapDaxConn("fuga");
+      var conn = getDaxConn("fuga", MapDaxConn.class);
       conn.dataMap.put("fugafuga", data);
     }
   }
 
-  static interface PiyoDax extends MapDax, FugaPiyoDax  {
+  static interface PiyoDax extends Dax, FugaPiyoDax  {
     default String getPiyoData() throws Err {
-      var conn = getMapDaxConn("piyo");
+      var conn = getDaxConn("piyo", MapDaxConn.class);
       var data = conn.dataMap.get("piyopiyo");
       return data;
     }
 
     default void setPiyoData(String data) throws Err {
-      var conn = getMapDaxConn("piyo");
+      var conn = getDaxConn("piyo", MapDaxConn.class);
       conn.dataMap.put("piyopiyo", data);
     }
   }
@@ -282,13 +275,6 @@ public class DaxDummyForTest {
     @Override
     public void close() {
       logs.add("ADaxConn#close");
-    }
-  }
-
-  static interface ADax extends Dax {
-    default ADaxConn getADaxConn(String name) throws Err {
-      var conn = getDaxConn(name);
-      return ADaxConn.class.cast(conn);
     }
   }
 
@@ -338,13 +324,6 @@ public class DaxDummyForTest {
     }
   }
 
-  static interface BDax extends Dax {
-    default BDaxConn getBDaxConn(String name) throws Err {
-      var conn = getDaxConn(name);
-      return BDaxConn.class.cast(conn);
-    }
-  }
-
   static class CDaxSrc implements DaxSrc {
     final Map<String, String> cMap = new HashMap<>();
 
@@ -382,13 +361,6 @@ public class DaxDummyForTest {
     @Override
     public void close() {
       logs.add("CDaxConn#close");
-    }
-  }
-
-  static interface CDax extends Dax {
-    default CDaxConn getCDaxConn(String name) throws Err {
-      var conn = getDaxConn(name);
-      return CDaxConn.class.cast(conn);
     }
   }
 }

--- a/src/test/java/sabi/DaxTest.java
+++ b/src/test/java/sabi/DaxTest.java
@@ -400,7 +400,7 @@ public class DaxTest {
         var base = new DaxBase() {};
 
         try {
-          var conn = base.getDaxConn("foo");
+          base.getDaxConn("foo", FooDaxConn.class);
           fail();
         } catch (Err e) {
           var r = DaxBase.DaxSrcIsNotFound.class.cast(e.getReason());
@@ -414,7 +414,7 @@ public class DaxTest {
         }
 
         try {
-          var conn = base.getDaxConn("foo");
+          base.getDaxConn("foo", FooDaxConn.class);
           fail();
         } catch (Err e) {
           var r = DaxBase.DaxSrcIsNotFound.class.cast(e.getReason());
@@ -427,9 +427,9 @@ public class DaxTest {
           fail(e);
         }
 
-        var conn = base.getDaxConn("foo");
+        var conn = base.getDaxConn("foo", FooDaxConn.class);
 
-        var conn2 = base.getDaxConn("foo");
+        var conn2 = base.getDaxConn("foo", FooDaxConn.class);
         assertThat(conn2).isEqualTo(conn);
       }
 
@@ -438,7 +438,7 @@ public class DaxTest {
         var base = new DaxBase() {};
 
         try {
-          var conn = base.getDaxConn("foo");
+          base.getDaxConn("foo", FooDaxConn.class);
           fail();
         } catch (Err e) {
           var r = DaxBase.DaxSrcIsNotFound.class.cast(e.getReason());
@@ -453,9 +453,9 @@ public class DaxTest {
           fail(e);
         }
 
-        var conn = base.getDaxConn("foo");
+        var conn = base.getDaxConn("foo", FooDaxConn.class);
 
-        var conn2 = base.getDaxConn("foo");
+        var conn2 = base.getDaxConn("foo", FooDaxConn.class);
         assertThat(conn2).isEqualTo(conn);
       }
 
@@ -464,7 +464,7 @@ public class DaxTest {
         var base = new DaxBase() {};
 
         try {
-          var conn = base.getDaxConn("foo");
+          base.getDaxConn("foo", FooDaxConn.class);
           fail();
         } catch (Err e) {
           var r = DaxBase.DaxSrcIsNotFound.class.cast(e.getReason());
@@ -485,9 +485,9 @@ public class DaxTest {
           fail(e);
         }
 
-        var conn = base.getDaxConn("foo");
+        var conn = base.getDaxConn("foo", FooDaxConn.class);
 
-        var conn2 = base.getDaxConn("foo");
+        var conn2 = base.getDaxConn("foo", FooDaxConn.class);
         assertThat(conn2).isEqualTo(conn);
       }
 
@@ -504,7 +504,7 @@ public class DaxTest {
         }
 
         try {
-          base.getDaxConn("foo");
+          base.getDaxConn("foo", FooDaxConn.class);
           fail();
         } catch (Err e) {
           var r = DaxBase.FailToCreateDaxConn.class.cast(e.getReason());
@@ -533,14 +533,14 @@ public class DaxTest {
         base.begin();
 
         try {
-          var conn = base.getDaxConn("foo");
+          var conn = base.getDaxConn("foo", FooDaxConn.class);
           assertThat(conn).isNotNull();
         } catch (Err e) {
           fail(e);
         }
 
         try {
-          var conn = base.getDaxConn("bar");
+          var conn = base.getDaxConn("bar", BarDaxConn.class);
           assertThat(conn).isNotNull();
         } catch (Err e) {
           fail(e);
@@ -587,14 +587,14 @@ public class DaxTest {
         base.begin();
 
         try {
-          var conn = base.getDaxConn("foo");
+          var conn = base.getDaxConn("foo", FooDaxConn.class);
           assertThat(conn).isNotNull();
         } catch (Err e) {
           fail(e);
         }
 
         try {
-          var conn = base.getDaxConn("bar");
+          var conn = base.getDaxConn("bar", BarDaxConn.class);
           assertThat(conn).isNotNull();
         } catch (Err e) {
           fail(e);
@@ -636,14 +636,14 @@ public class DaxTest {
         base.begin();
 
         try {
-          var conn = base.getDaxConn("foo");
+          var conn = base.getDaxConn("foo", FooDaxConn.class);
           assertThat(conn).isNotNull();
         } catch (Err e) {
           fail(e);
         }
 
         try {
-          var conn = base.getDaxConn("bar");
+          var conn = base.getDaxConn("bar", BarDaxConn.class);
           assertThat(conn).isNotNull();
         } catch (Err e) {
           fail(e);
@@ -684,14 +684,14 @@ public class DaxTest {
         base.begin();
 
         try {
-          var conn = base.getDaxConn("foo");
+          var conn = base.getDaxConn("foo", FooDaxConn.class);
           assertThat(conn).isNotNull();
         } catch (Err e) {
           fail(e);
         }
 
         try {
-          var conn = base.getDaxConn("bar");
+          var conn = base.getDaxConn("bar", BarDaxConn.class);
           assertThat(conn).isNotNull();
         } catch (Err e) {
           fail(e);

--- a/src/test/java/sabi/TxnTest.java
+++ b/src/test/java/sabi/TxnTest.java
@@ -21,30 +21,30 @@ public class TxnTest {
     void setBData(String data) throws Err;
   }
 
-  static interface AGetDax extends ABDax, ADax {
+  static interface AGetDax extends ABDax, Dax {
     default String getAData() throws Err {
-      var conn = getADaxConn("aaa");
+      var conn = getDaxConn("aaa", ADaxConn.class);
       var data = conn.aMap.get("a");
       return data;
     }
   }
 
-  static interface BGetSetDax extends ABDax, BDax {
+  static interface BGetSetDax extends ABDax, Dax {
     default String getBData() throws Err {
-      var conn = getBDaxConn("bbb");
+      var conn = getDaxConn("bbb", BDaxConn.class);
       var data = conn.bMap.get("b");
       return data;
     }
 
     default void setBData(String data) throws Err {
-      var conn = getBDaxConn("bbb");
+      var conn = getDaxConn("bbb", BDaxConn.class);
       conn.bMap.put("b", data);
     }
   }
 
-  static interface CSetDax extends ABDax, CDax {
+  static interface CSetDax extends ABDax, Dax {
     default void setCData(String data) throws Err {
-      var conn = getCDaxConn("ccc");
+      var conn = getDaxConn("ccc", CDaxConn.class);
       conn.cMap.put("c", data);
     }
   }


### PR DESCRIPTION
This PR changed `Dax#GetDaxConn` and `DaxBase#GetDaxConn` to cast a returned `DaxConn` by using generics type parameter and adding a cast destination class to their arguments.

By this changes, a dax interface by a dax source becomes unnecessary.